### PR TITLE
Honor non-default alignment settings

### DIFF
--- a/lib/animated_fractionally_sized_box.dart
+++ b/lib/animated_fractionally_sized_box.dart
@@ -112,6 +112,7 @@ class _AnimatedFractionallySizedBoxState
     return FractionallySizedBox(
       widthFactor: _widthFactor?.evaluate(animation),
       heightFactor: _heightFactor?.evaluate(animation),
+      alignment: (_alignment?.evaluate(animation))!,
       child: widget.child,
     );
   }


### PR DESCRIPTION
This package was exactly what I was looking for, except that the `alignment` property provided to `AnimatedFractionallySizedBox` wasn't finding its way to the underlying `FractionallySizedBox`.

I believe this change fixes that issue.